### PR TITLE
In examples

### DIFF
--- a/example/Bluetooth_AT_Command/Bluetooth_AT_Command.ino
+++ b/example/Bluetooth_AT_Command/Bluetooth_AT_Command.ino
@@ -11,7 +11,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 
@@ -27,7 +27,7 @@ int start = 0;
     
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("Bluetooth AT Command Test...");
   bluetooth.preInit();
   delay(3*1000);

--- a/example/Bluetooth_Communicate/Bluetooth_Communicate.ino
+++ b/example/Bluetooth_Communicate/Bluetooth_Communicate.ino
@@ -15,7 +15,7 @@ note: the following pins has been used and should not be used for other purposes
 this code has not been test because I have no Bluetooth with SPP 
 Profile, I will test it later!
 
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 
@@ -32,7 +32,7 @@ int start = 0;
     
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("Bluetooth Communication Test...");
   bluetooth.preInit();
   delay(3*1000);

--- a/example/FM_Test/FM_Test.ino
+++ b/example/FM_Test/FM_Test.ino
@@ -9,7 +9,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 
@@ -22,7 +22,7 @@ FM fm;
 void setup() {
   pinMode(channelButton,INPUT);
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("FM Test...");
   fm.preInit();
   while(0 != fm.powerOn()){
@@ -44,8 +44,3 @@ void loop() {
     delay(50);
   }
 }
-
-
-
-
-

--- a/example/GPRS_CallUp/GPRS_CallUp.ino
+++ b/example/GPRS_CallUp/GPRS_CallUp.ino
@@ -10,7 +10,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 
@@ -21,7 +21,7 @@ GPRS gprs;
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("GPRS - Call up Test...");
   gprs.preInit();//power on SIM800
   delay(1000);

--- a/example/GPRS_ConnectTCP/GPRS_ConnectTCP.ino
+++ b/example/GPRS_ConnectTCP/GPRS_ConnectTCP.ino
@@ -11,7 +11,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 #include <gprs.h>
@@ -52,7 +52,7 @@ STOP:
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("GPRS - TCP Connection Test...");
   pinMode(soundSensor,INPUT);
   gprs.preInit();
@@ -79,5 +79,3 @@ void loop() {
   delay(1000);
   Serial.println("loop");
 }
-
-

--- a/example/GPRS_LoopHandle/GPRS_LoopHandle.ino
+++ b/example/GPRS_LoopHandle/GPRS_LoopHandle.ino
@@ -11,7 +11,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 #include <gprs.h>
@@ -27,7 +27,7 @@ GPRS gprs;
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("GPRS - LoopHandle Test...");
   gprs.preInit();
   while(0 != gprs.init()) {

--- a/example/GPRS_SendSMS/GPRS_SendSMS.ino
+++ b/example/GPRS_SendSMS/GPRS_SendSMS.ino
@@ -10,7 +10,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 ************************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 #include <gprs.h>
@@ -20,7 +20,7 @@ GPRS gprs;
 
 void setup() {
   Serial.begin(9600);
-  while(!Serial);;
+  while(!Serial);
   Serial.println("GPRS - Send SMS Test ...");
   gprs.preInit();
   delay(1000);

--- a/example/SIM800_Serial_Debug/SIM800_Serial_Debug.ino
+++ b/example/SIM800_Serial_Debug/SIM800_Serial_Debug.ino
@@ -9,7 +9,7 @@ note: the following pins has been used and should not be used for other purposes
   pin 9   // power key pin
   pin 12  // power status pin
 *********************************************************************************
-create on 2013/12/5, version: 0.1
+created on 2013/12/5, version: 0.1
 by lawliet.zou(lawliet.zou@gmail.com)
 */
 
@@ -26,6 +26,3 @@ void setup(){
 void loop(){
   sim800.serialDebug();
 }
-
-
-


### PR DESCRIPTION
- Removed redundant double semicolons
- "create on" -> "created on" (fixed typo)
- small cleanups (removed redundant empty lines at the end).
